### PR TITLE
feat: 串接 Google Map API 並取得咖啡廳資料

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "kka-pe",
       "version": "0.1.0",
       "dependencies": {
+        "@googlemaps/js-api-loader": "^1.16.8",
         "next": "15.0.3",
         "react": "19.0.0-rc-66855b96-20241106",
         "react-dom": "19.0.0-rc-66855b96-20241106"
       },
       "devDependencies": {
+        "@types/google.maps": "^3.58.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -108,6 +110,11 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -839,6 +846,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@googlemaps/js-api-loader": "^1.16.8",
     "react": "19.0.0-rc-66855b96-20241106",
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "next": "15.0.3"
   },
   "devDependencies": {
     "typescript": "^5",
+    "@types/google.maps": "^3.58.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/components/info.tsx
+++ b/src/app/components/info.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+export default function Info() {
+  return (
+    <div className="fixed left-16 top-1/2 transform -translate-y-1/2 w-2/5 h-2/3 bg-gray-200 rounded text-black p-16">
+      <h2 className="text-xl font-bold">店家名稱</h2>
+      <a className="text-blue-700 underline underline-offset-auto" href="#">
+        網站連結
+      </a>
+      <ul className="mt-6">
+        <li>是否營業中：</li>
+        <li>評分：</li>
+        <li>地址：</li>
+        <li>電話：</li>
+      </ul>
+    </div>
+  );
+}

--- a/src/app/components/map.tsx
+++ b/src/app/components/map.tsx
@@ -25,6 +25,15 @@ export default function Map() {
         };
         // setup the map
         const map = new Map(mapRef.current as HTMLDivElement, mapOptions);
+        let currentPosition;
+        navigator.geolocation.getCurrentPosition(function (position) {
+          currentPosition = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+          };
+          map.setCenter(currentPosition);
+          map.setZoom(16);
+        });
       } catch (error) {
         console.error('Error loading Google Maps:', error);
       }

--- a/src/app/components/map.tsx
+++ b/src/app/components/map.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { Loader } from '@googlemaps/js-api-loader';
+
+export default function Map() {
+  const mapRef = React.useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const initMap = async () => {
+      try {
+        const loader = new Loader({
+          apiKey: process.env.NEXT_PUBLIC_MAPS_API_KEY as string,
+          version: 'weekly',
+        });
+        const { Map } = await loader.importLibrary('maps');
+
+        // map options
+        const mapOptions: google.maps.MapOptions = {
+          center: {
+            lat: 23.553118,
+            lng: 121.0211024,
+          },
+          zoom: 9,
+        };
+        // setup the map
+        const map = new Map(mapRef.current as HTMLDivElement, mapOptions);
+      } catch (error) {
+        console.error('Error loading Google Maps:', error);
+      }
+    };
+    initMap();
+  }, []);
+
+  return (
+    <div className="absolute top-0 right-0 w-1/2 h-screen bg-gray-200">
+      <div
+        style={{
+          height: '100vh',
+          width: '50vw',
+        }}
+        ref={mapRef}
+      />
+    </div>
+  );
+}

--- a/src/app/components/map.tsx
+++ b/src/app/components/map.tsx
@@ -14,14 +14,16 @@ export default function Map() {
           version: 'weekly',
         });
         const { Map } = await loader.importLibrary('maps');
-
+        const { AdvancedMarkerElement } = await loader.importLibrary('marker');
+        const position = {
+          lat: 24.998259,
+          lng: 121.517034,
+        };
         // map options
         const mapOptions: google.maps.MapOptions = {
-          center: {
-            lat: 23.553118,
-            lng: 121.0211024,
-          },
+          center: position,
           zoom: 9,
+          mapId: 'KKA_PE_MAP_ID',
         };
         // setup the map
         const map = new Map(mapRef.current as HTMLDivElement, mapOptions);
@@ -33,6 +35,12 @@ export default function Map() {
           };
           map.setCenter(currentPosition);
           map.setZoom(16);
+        });
+        // put up a marker
+        const marker = new AdvancedMarkerElement({
+          map,
+          position,
+          title: 'First coffee shop',
         });
       } catch (error) {
         console.error('Error loading Google Maps:', error);

--- a/src/app/components/map.tsx
+++ b/src/app/components/map.tsx
@@ -6,6 +6,35 @@ import { Loader } from '@googlemaps/js-api-loader';
 export default function Map() {
   const mapRef = React.useRef<HTMLDivElement | null>(null);
 
+  // Example JSON data with five coffee shops
+  const data = [
+    {
+      name: 'OH MY ZOO 寵物咖啡廳',
+      lat: 25.0425012,
+      lng: 121.5521667,
+    },
+    {
+      name: '倉鼠甜點工作室',
+      lat: 25.0392103,
+      lng: 121.5253616,
+    },
+    {
+      name: 'Tart club 蛋塔俱樂部(每月公休以ig發佈為主）',
+      lat: 25.0554109,
+      lng: 121.5188856,
+    },
+    {
+      name: '富富',
+      lat: 25.0462952,
+      lng: 121.5102851,
+    },
+    {
+      name: '灯火 AKARI 深夜咖啡（最後點餐為11點，無接待四人以上組別，營業時間請參考Ig公告）',
+      lat: 24.9978364,
+      lng: 121.5171202,
+    },
+  ];
+
   useEffect(() => {
     const initMap = async () => {
       try {
@@ -36,11 +65,17 @@ export default function Map() {
           map.setCenter(currentPosition);
           map.setZoom(16);
         });
-        // put up a marker
-        const marker = new AdvancedMarkerElement({
-          map,
-          position,
-          title: 'First coffee shop',
+        // Create marker for each coffee shop
+        data.forEach((shop) => {
+          const position = {
+            lat: shop.lat,
+            lng: shop.lng,
+          };
+          const marker = new AdvancedMarkerElement({
+            map,
+            position,
+            title: shop.name,
+          });
         });
       } catch (error) {
         console.error('Error loading Google Maps:', error);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
         </div>
         <Map />
       </main>
-      <Script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyACloyFqZHDGRy5RwasW3unXxQ5EbdaPa0&loading=async&libraries=places&callback=initMap" />
+      <Script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyACloyFqZHDGRy5RwasW3unXxQ5EbdaPa0&loading=async&libraries=places&callback=initMap&libraries=marker" />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import Map from '@/app/components/map';
 import Info from '@/app/components/info';
 
 export default function Home() {
+  const apiKey = process.env.NEXT_PUBLIC_MAPS_API_KEY;
+
   return (
     <div className="min-h-screen p-8 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 items-center sm:items-start">
@@ -13,7 +15,9 @@ export default function Home() {
         <Info />
         <Map />
       </main>
-      <Script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyACloyFqZHDGRy5RwasW3unXxQ5EbdaPa0&loading=async&libraries=places&callback=initMap&libraries=marker" />
+      <Script
+        src={`https://maps.googleapis.com/maps/api/js?key=${apiKey}&loading=async&libraries=places&callback=initMap&libraries=marker`}
+      />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Script from 'next/script';
 import Map from '@/app/components/map';
+import Info from '@/app/components/info';
 
 export default function Home() {
   return (
@@ -9,6 +10,7 @@ export default function Home() {
           <h1 className="text-4xl font-extrabold">KKA-PE</h1>
           <span className="text-4xl font-extrabold">?</span>
         </div>
+        <Info />
         <Map />
       </main>
       <Script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyACloyFqZHDGRy5RwasW3unXxQ5EbdaPa0&loading=async&libraries=places&callback=initMap&libraries=marker" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,101 +1,12 @@
-import Image from 'next/image';
-
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2">
-            Get started by editing{' '}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:min-w-44"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+    <div className="min-h-screen p-8 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <main className="flex flex-col gap-8 items-center sm:items-start">
+        <div className="flex justify-between fixed top-10 left-0 px-8 w-full z-10">
+          <h1 className="text-4xl font-extrabold">KKA-PE</h1>
+          <span className="text-4xl font-extrabold">?</span>
         </div>
       </main>
-      <footer className="row-start-3 flex gap-6 flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Script from 'next/script';
+import Map from '@/app/components/map';
 
 export default function Home() {
   return (
@@ -8,6 +9,7 @@ export default function Home() {
           <h1 className="text-4xl font-extrabold">KKA-PE</h1>
           <span className="text-4xl font-extrabold">?</span>
         </div>
+        <Map />
       </main>
       <Script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyACloyFqZHDGRy5RwasW3unXxQ5EbdaPa0&loading=async&libraries=places&callback=initMap" />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Script from 'next/script';
+
 export default function Home() {
   return (
     <div className="min-h-screen p-8 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
@@ -7,6 +9,7 @@ export default function Home() {
           <span className="text-4xl font-extrabold">?</span>
         </div>
       </main>
+      <Script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyACloyFqZHDGRy5RwasW3unXxQ5EbdaPa0&loading=async&libraries=places&callback=initMap" />
     </div>
   );
 }


### PR DESCRIPTION
## Story/Why
UI 上做到基礎畫面呈現，並串接 Google Map API 且進一步取得咖啡廳店家 (mock data) 的詳細地點資訊

## What has been done
- Google Map API 串接及設置
- 保護 API Key 金鑰
- 先透過五間咖啡廳 mock data 作出預期呈現效果
- 放置圖標並增加點擊事件以取得咖啡廳資訊
- UI 上除了主要的右半部地圖區塊之外，加上 Navbar 的 logo 及問號（之後的使用導覽按鈕），還有左半部預計呈現咖啡廳資訊的卡片

## Additional Notes
暴露了 API Key，有碰到 GitHub 官方提醒所以重新產生一組金鑰，並改為使用 `NEXT_PUBLIC_MAPS_API_KEY` 取得放在 .env.local 環境變數裡的新的一組金鑰

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/75d37a1d-0810-421a-a7eb-4602c8cc8277">

